### PR TITLE
Correct Test for df result2 and result5

### DIFF
--- a/project_gp.ipynb
+++ b/project_gp.ipynb
@@ -2557,7 +2557,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert result2 == result5"
+    "# This will raise an AssertionError if result 2 and result 5are not exactly the same\n",
+    "assert result2.equals(result5), \"DataFrames result2 and result5 are not identical.\""
    ]
   },
   {


### PR DESCRIPTION
Correct Test for df result2 and result5: use assert result2.equals(result5), "DataFrames result2 and result5 are not identical."